### PR TITLE
Handle API exceptions differently for CLI and web

### DIFF
--- a/src/Libilsws.php
+++ b/src/Libilsws.php
@@ -113,6 +113,20 @@ class Libilsws
             . $this->config['ilsws']['webapp'];
     }
 
+    private function handle_exception($message = '')
+    {
+        if ( php_sapi_name() === 'cli' || PHP_SAPI === 'cli') {
+
+            // Running in CLI mode: print to STDERR
+            fwrite(STDERR, "Error: " . $message . PHP_EOL);
+
+        } else {
+
+            // Running in web mode: log the error
+            error_log($message);
+        }
+    }
+
     /**
      * Validate call or item input fields using the API describe function
      * 
@@ -234,7 +248,7 @@ class Libilsws
 
         } catch (APIException $e) {
 
-            echo $e->errorMessage($this->error, $this->code), "\n";
+            $this->handle_exception($e->errorMessage($this->error, $this->code));
         } 
 
         return $token;
@@ -320,7 +334,7 @@ class Libilsws
 
         } catch (APIException $e) {
 
-            echo $e->errorMessage($this->error, $this->code), "\n";
+            $this->handle_exception($e->errorMessage($this->error, $this->code));
         } 
 
         return json_decode($json, true);
@@ -413,7 +427,7 @@ class Libilsws
 
         } catch (APIException $e) {
 
-            echo $e->errorMessage($this->error, $this->code), "\n";
+            $this->handle_exception($e->errorMessage($this->error, $this->code));
         }
         
         return json_decode($json, true);

--- a/test/get_item_circ_info.php
+++ b/test/get_item_circ_info.php
@@ -1,0 +1,30 @@
+<?php
+
+require_once 'vendor/autoload.php';
+
+if ( count($argv) < 2 ) {
+    print "Syntax: php $argv[0] ITEM_BARCODE\n";
+    exit;
+} 
+
+$barcode = $argv[1];
+
+// Initialize
+$ilsws = new Libilsws\Libilsws("./libilsws.yaml");
+
+// Connect and get token
+$token = $ilsws->connect();
+
+$json = "{\"itemBarcode\":\"$barcode\"}";
+
+// Add header and role required for this API endpoint
+$options = [];
+$options['role'] = 'STAFF';
+     
+// Describe patron register function
+$response = $ilsws->send_query("$ilsws->base_url/circulation/itemCircInfo/advise", $token, $json, 'POST', $options);
+
+$json = json_encode($response, JSON_PRETTY_PRINT);
+print "$json\n\n";
+
+// EOF


### PR DESCRIPTION
CLI errors will be printed to STDERR, but web errors will only be logged (with the $error and $code globals set).